### PR TITLE
Implement the CLEANING_MODE_MATCHING_ANY_TAG option

### DIFF
--- a/library/Zend/Cache/Backend/Memcached.php
+++ b/library/Zend/Cache/Backend/Memcached.php
@@ -287,12 +287,12 @@ class Memcached extends AbstractBackend implements ExtendedBackend
 				break;
             case Cache\Cache::CLEANING_MODE_MATCHING_ANY_TAG:
 		   $flag = true;
-		   foreach($tags as $tag) {
+		   foreach ($tags as $tag) {
 		       $keysToClear = $this->getIdsMatchingTags($tag);
 
-		       foreach($keysToClear as $key) {
+		       foreach ($keysToClear as $key) {
 			       if (!$this->_memcache->delete($key)) {
-				       $flag = false;
+				    $flag = false;
 			       }
 		       }
 
@@ -369,7 +369,7 @@ class Memcached extends AbstractBackend implements ExtendedBackend
     public function getIdsMatchingTags($tags = array())
     {
 		$matches = array();
-		if(!is_array($tags)) {
+		if (!is_array($tags)) {
 			$tags = [$tags];
 		}
         foreach ($tags as $tag) {


### PR DESCRIPTION
ACL caching was not being cleaned properly when ACLs were deleted as this option had not been implemented and hence the `clean()` call was silently failing.